### PR TITLE
Update dependency versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ package_dir=
     =src
 packages=find_namespace:
 install_requires =
-    deephaven
-    deephaven-jpy
+    deephaven>=0.14.0
+    jpy>=0.11.0
     deephaven-plugin
     matplotlib
 include_package_data = True

--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from matplotlib.animation import Animation
 import itertools
 
-__version__ = "0.0.1.dev7"
+__version__ = "0.0.1.dev8"
 
 def _init_theme():
     # Set the Deephaven style globally.


### PR DESCRIPTION
- Require deephaven>=0.14.0
- Update deephaven-jpy dependency to just jpy

**Testing Done:**
- Rebuilt the wheel running `python -m build --wheel`
- Copy the wheel to the docker container and run `pip install` on it without the `--no-deps` flag, and it succeeded (this step fails on dev7 without the `--no-deps` flag):
```
docker cp dist/deephaven_plugin_matplotlib-0.0.1.dev8-py3-none-any.whl deephaven-matplotlib-base_server_1:/tmp && docker exec deephaven-matplotlib-base_server_1 pip install /tmp/deephaven_plugin_matplotlib-0.0.1.dev8-py3-none-any.whl
```
- Open up the web UI at http://localhost:10000/ide/, run the examples from the README.md.