### PR TITLE
Switch to the 'AGG' backend

### DIFF
--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -20,6 +20,7 @@ class MatplotlibRegistration(Registration):
     @classmethod
     def register_into(cls, callback: Registration.Callback) -> None:
         _init_theme()
+        plt.switch_backend('AGG')
         from . import figure_type
         callback.register(figure_type.FigureType)
 


### PR DESCRIPTION
- matplotlib was selecting a backend by default, which caused issues on macos when it selected the macos backend
- We do not want a backend to be selected, as we just render the image and pass to the plugin
- See docs in matplotlib for more info on backends:https://matplotlib.org/stable/users/explain/backends.html#the-builtin-backends
- Fixes #8
