### PR TITLE
Use `.to_numpy` instead of `.getDirect()`

### DIFF
--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -1,3 +1,4 @@
+from deephaven import numpy as dhnp
 from deephaven.plugin import Registration
 from deephaven.table_listener import listen
 from importlib import resources
@@ -156,5 +157,5 @@ class TableAnimation(Animation):
     def _draw_frame(self, framedata):
         data = {}
         for column in self._columns:
-            data[column] = self._table.j_table.getColumn(column).getDirect()
+            data[column] = dhnp.to_numpy(self._table, [column])
         self._func(data, self._last_update, *self._args)

--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -129,7 +129,7 @@ class TableAnimation(Animation):
             self._args = ()
         self._func = func
         self._table = table
-        if not columns:
+        if columns is None:
             self._columns = [column.name for column in table.columns]
         else:
             self._columns = columns

--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 from matplotlib.animation import Animation
 import itertools
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 def _init_theme():
     # Set the Deephaven style globally.


### PR DESCRIPTION
- Python doesn't know how to pickle a java array
- Fixes #891
- Still not optimal, as this will have performance issues on large tables
- Optimization: Pass in an array for the `columns` parameter to only send along data you need
- Version bump to 0.1.1
- Tested with all of the examples in the readme
