### PR TITLE
fix: Pass data update in the correct format rather than as 2d array

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     jpy>=0.11.0
     deephaven-plugin
     matplotlib
+    numpy
 include_package_data = True
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
     jpy>=0.11.0
     deephaven-plugin
     matplotlib
-    numpy
 include_package_data = True
 
 [options.packages.find]

--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -5,6 +5,7 @@ from importlib import resources
 import matplotlib.pyplot as plt
 from matplotlib.animation import Animation
 import itertools
+from numpy import ndarray
 
 __version__ = "0.1.1"
 
@@ -157,5 +158,6 @@ class TableAnimation(Animation):
     def _draw_frame(self, framedata):
         data = {}
         for column in self._columns:
-            data[column] = dhnp.to_numpy(self._table, [column])
+            data[column] = ndarray.flatten(dhnp.to_numpy(self._table, [column]))
+
         self._func(data, self._last_update, *self._args)

--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -5,12 +5,9 @@ from importlib import resources
 import matplotlib.pyplot as plt
 from matplotlib.animation import Animation
 import itertools
-import jpy
 from numpy import ndarray
 
 __version__ = "0.1.1"
-
-_JDataAccessHelpers = jpy.get_type("io.deephaven.engine.table.impl.DataAccessHelpers")
 
 def _init_theme():
     # Set the Deephaven style globally.
@@ -135,10 +132,8 @@ class TableAnimation(Animation):
         self._table = table
         if columns is None:
             self._columns = [column.name for column in table.columns]
-            self._column_defs = table.columns
         else:
             self._columns = columns
-            self._column_defs = [[column_def for column_def in table.columns if x.name == column] for column in columns]
         self._last_update = None
         event_source = TableEventSource(table)
         super().__init__(fig, event_source, **kwargs)
@@ -162,8 +157,7 @@ class TableAnimation(Animation):
 
     def _draw_frame(self, framedata):
         data = {}
-        for i, column in enumerate(self._columns):
-            data_col = _JDataAccessHelpers.getColumn(self._table.j_table, column)
-            data[column] = dhnp.column_to_numpy_array(self._column_defs[i], data_col.getDirect())
+        for column in self._columns:
+            data[column] = ndarray.flatten(dhnp.to_numpy(self._table, [column]))
 
         self._func(data, self._last_update, *self._args)

--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -5,7 +5,6 @@ from importlib import resources
 import matplotlib.pyplot as plt
 from matplotlib.animation import Animation
 import itertools
-from numpy import ndarray
 
 __version__ = "0.1.1"
 
@@ -158,6 +157,5 @@ class TableAnimation(Animation):
     def _draw_frame(self, framedata):
         data = {}
         for column in self._columns:
-            data[column] = ndarray.flatten(dhnp.to_numpy(self._table, [column]))
-
+            data[column] = dhnp.to_numpy(self._table, [column])
         self._func(data, self._last_update, *self._args)

--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -5,9 +5,12 @@ from importlib import resources
 import matplotlib.pyplot as plt
 from matplotlib.animation import Animation
 import itertools
+import jpy
 from numpy import ndarray
 
 __version__ = "0.1.1"
+
+_JDataAccessHelpers = jpy.get_type("io.deephaven.engine.table.impl.DataAccessHelpers")
 
 def _init_theme():
     # Set the Deephaven style globally.
@@ -132,8 +135,10 @@ class TableAnimation(Animation):
         self._table = table
         if columns is None:
             self._columns = [column.name for column in table.columns]
+            self._column_defs = table.columns
         else:
             self._columns = columns
+            self._column_defs = [[column_def for column_def in table.columns if x.name == column] for column in columns]
         self._last_update = None
         event_source = TableEventSource(table)
         super().__init__(fig, event_source, **kwargs)
@@ -157,7 +162,8 @@ class TableAnimation(Animation):
 
     def _draw_frame(self, framedata):
         data = {}
-        for column in self._columns:
-            data[column] = ndarray.flatten(dhnp.to_numpy(self._table, [column]))
+        for i, column in enumerate(self._columns):
+            data_col = _JDataAccessHelpers.getColumn(self._table.j_table, column)
+            data[column] = dhnp.column_to_numpy_array(self._column_defs[i], data_col.getDirect())
 
         self._func(data, self._last_update, *self._args)

--- a/src/deephaven/plugin/matplotlib/__init__.py
+++ b/src/deephaven/plugin/matplotlib/__init__.py
@@ -157,5 +157,5 @@ class TableAnimation(Animation):
     def _draw_frame(self, framedata):
         data = {}
         for column in self._columns:
-            data[column] = dhnp.to_numpy(self._table, [column])
+            data[column] = dhnp.to_numpy(self._table, [column])[:, 0]
         self._func(data, self._last_update, *self._args)


### PR DESCRIPTION
- Was passing each column of data as a 2d array instead of just a single dimensional array
- Wasn't being caught before, as there was a change in numpy 1.24 that now causes an error when data is incorrectly shaped: https://github.com/numpy/numpy/issues/23231
- Get the column data from numpy instead of as a table
- Tested using the following code snippet:
```
from deephaven import time_table

def get_ticking_table():
    return time_table("PT00:00:02")

import matplotlib.pyplot as plt
from deephaven.plugin.matplotlib import TableAnimation
from deephaven import SortDirection

top_n = 5
matplotlibTableBar = get_ticking_table() \
    .update(["x=i", "y=i"]) \
    .sort(order_by=["y"], order=[SortDirection.DESCENDING]) \
    .head(top_n)
figBar, axBar = plt.subplots()
rects = axBar.bar(range(top_n), [0] * top_n)
def update_fig_bar(data, update):
    for rect, h in zip(rects, data["y"]):
        rect.set_height(h)
    axBar.set_xticks(range(len(data["x"])))
    axBar.set_xticklabels(data["x"])
    axBar.relim()
    axBar.autoscale_view(True, True, True)
aniBar = TableAnimation(figBar, matplotlibTableBar, update_fig_bar)
```